### PR TITLE
Fix bug in auto exec detection

### DIFF
--- a/index.js
+++ b/index.js
@@ -165,16 +165,16 @@ class RenderPDF {
         }
         // macos
         if(await this.isCommandExists('/Applications/Google\ Chrome Canary.app/Contents/MacOS/Google\ Chrome')) {
-            return '/Applications/Google\ Chrome Canary.app/Contents/MacOS/Google\ Chrome';
+            return '/Applications/Google\\ Chrome Canary.app/Contents/MacOS/Google\\ Chrome';
         }
         if(await this.isCommandExists('/Applications/Google\ Chrome Dev.app/Contents/MacOS/Google\ Chrome')) {
-            return '/Applications/Google\ Chrome Dev.app/Contents/MacOS/Google\ Chrome';
+            return '/Applications/Google\\ Chrome Dev.app/Contents/MacOS/Google\\ Chrome';
         }
         if(await this.isCommandExists('/Applications/Google\ Chrome Beta.app/Contents/MacOS/Google\ Chrome')) {
-            return '/Applications/Google\ Chrome Beta.app/Contents/MacOS/Google\ Chrome';
+            return '/Applications/Google\\ Chrome Beta.app/Contents/MacOS/Google\\ Chrome';
         }
         if(await this.isCommandExists('/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome')) {
-            return '/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome';
+            return '/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome';
         }
         throw Error('Couldn\'t detect chrome version installed! use --chrome-binary to pass custom location');
     }


### PR DESCRIPTION
I've got error with Chrome 59:

```
Using /Applications/Google Chrome.app/Contents/MacOS/Google Chrome
Waiting for chrome to became available
Chrome stopped
(chrome) (out) 
(chrome) (err) /bin/sh: /Applications/Google: No such file or directory
(chrome) (err)
```

This PR will fix this issue. Thank you.