### PR TITLE
Add --no-sandbox to Chrome/Chromium binary exec

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,7 +161,7 @@ class RenderPDF {
     async spawnChrome() {
         const chromeExec = this.options.chromeBinary || await this.detectChrome();
         this.log('Using', chromeExec);
-        this.chrome = cp.exec(`${chromeExec} --headless --remote-debugging-port=${this.port} --disable-gpu`, (err, stdout, stderr) => {
+        this.chrome = cp.exec(`${chromeExec} --headless --remote-debugging-port=${this.port} --disable-gpu --no-sandbox`, (err, stdout, stderr) => {
             this.browserLog('out', stdout);
             this.browserLog('err', stderr);
         });


### PR DESCRIPTION
The Chrome/Chromium sandbox currently does not work within a Docker container. Adding --no-sandbox as one of the command line options allows Chrome/Chromium to execute properly within a Docker container.