### PR TITLE
Adding commandline option for window size to be passed to the chrome

### DIFF
--- a/cli/chrome-headless-render-pdf.js
+++ b/cli/chrome-headless-render-pdf.js
@@ -32,6 +32,13 @@ if (argv['help'] || !argv['pdf'] || !argv['url']) {
 
 const urls = typeof argv['url'] === 'string' ? [argv['url']] : argv['url'];
 const pdfs = typeof argv['pdf'] === 'string' ? [argv['pdf']] : argv['pdf'];
+
+if (typeof argv['window-size'] === 'string' && argv['window-size'].indexOf(',') < 0) {
+    console.error('ERROR: Missing comma in --window-size\n');
+    printHelp();
+    process.exit();
+}
+
 const windowSize = typeof argv['window-size'] === 'string' ? argv['window-size'].split(',') : argv['window-size'];
 
 if (pdfs.length !== urls.length) {

--- a/cli/chrome-headless-render-pdf.js
+++ b/cli/chrome-headless-render-pdf.js
@@ -107,6 +107,7 @@ function printHelp() {
     console.log('    --no-margins             disable default 1cm margins');
     console.log('    --include-background     include elements background');
     console.log('    --landscape              generate pdf in landscape orientation');
+    console.log('    --window-size            specify window size (e.g. --window-size 1600,1200)');
     console.log('');
     console.log('  Example:');
     console.log('    Render single pdf file');

--- a/cli/chrome-headless-render-pdf.js
+++ b/cli/chrome-headless-render-pdf.js
@@ -15,7 +15,8 @@ const argv = require('minimist')(process.argv.slice(2), {
     string: [
         'url',
         'pdf',
-        'chrome-binary'
+        'chrome-binary',
+        'window-size'
     ],
     boolean: [
         'no-margins',
@@ -31,6 +32,7 @@ if (argv['help'] || !argv['pdf'] || !argv['url']) {
 
 const urls = typeof argv['url'] === 'string' ? [argv['url']] : argv['url'];
 const pdfs = typeof argv['pdf'] === 'string' ? [argv['pdf']] : argv['pdf'];
+const windowSize = typeof argv['window-size'] === 'string' ? argv['window-size'].split(',') : argv['window-size'];
 
 if (pdfs.length !== urls.length) {
     console.error('ERROR: Unpaired --url or --pdf found\n');
@@ -66,7 +68,8 @@ if (argv['include-background']) {
             landscape,
             noMargins,
             includeBackground,
-            chromeBinary
+            chromeBinary,
+            windowSize
         });
     } catch (e) {
         console.error(e);

--- a/cli/chrome-headless-render-pdf.js
+++ b/cli/chrome-headless-render-pdf.js
@@ -33,13 +33,17 @@ if (argv['help'] || !argv['pdf'] || !argv['url']) {
 const urls = typeof argv['url'] === 'string' ? [argv['url']] : argv['url'];
 const pdfs = typeof argv['pdf'] === 'string' ? [argv['pdf']] : argv['pdf'];
 
-if (typeof argv['window-size'] === 'string' && argv['window-size'].indexOf(',') < 0) {
-    console.error('ERROR: Missing comma in --window-size\n');
-    printHelp();
-    process.exit();
+let windowSize;
+if (typeof argv['window-size'] === 'string') {
+    windowSize = argv['window-size'].match(/^([0-9]+)[,x*]([0-9]+)$/);
+    if (windowSize === null) {
+      console.error('ERROR: Missing or bad input for --window-size \n');
+      printHelp();
+      process.exit();
+    }
+    windowSize = windowSize.splice(1,3);
 }
 
-const windowSize = typeof argv['window-size'] === 'string' ? argv['window-size'].split(',') : argv['window-size'];
 
 if (pdfs.length !== urls.length) {
     console.error('ERROR: Unpaired --url or --pdf found\n');
@@ -107,7 +111,7 @@ function printHelp() {
     console.log('    --no-margins             disable default 1cm margins');
     console.log('    --include-background     include elements background');
     console.log('    --landscape              generate pdf in landscape orientation');
-    console.log('    --window-size            specify window size (e.g. --window-size 1600,1200)');
+    console.log('    --window-size            specify window size, width(,x*)height (e.g. --window-size 1600,1200 or --window-size 1600x1200)');
     console.log('');
     console.log('  Example:');
     console.log('    Render single pdf file');

--- a/index.js
+++ b/index.js
@@ -21,6 +21,10 @@ class RenderPDF {
             includeBackground: def('includeBackground', undefined)
         };
 
+        this.commandLineOptions = {
+            windowSize: def('windowSize', undefined),
+        };
+
         function def(key, defaultValue) {
             return options[key] === undefined ? defaultValue : options[key];
         }
@@ -160,9 +164,19 @@ class RenderPDF {
     async spawnChrome() {
         const chromeExec = this.options.chromeBinary || await this.detectChrome();
         this.log('Using', chromeExec);
+        const commandLineOptions = [
+             '--headless', 
+             `--remote-debugging-port=${this.port}`, 
+             '--disable-gpu'
+            ];
+
+        if (this.commandLineOptions.windowSize !== undefined ) {
+          commandLineOptions.push(`--window-size=${this.commandLineOptions.windowSize[0]},${this.commandLineOptions.windowSize[1]}`);
+
+        }
         this.chrome = cp.spawn(
             chromeExec,
-            ['--headless', `--remote-debugging-port=${this.port}`, '--disable-gpu']
+            commandLineOptions
         );
         this.chrome.on('close', (code) => {
             this.log(`Chrome stopped (${code})`);


### PR DESCRIPTION
Here is pull request for #13
 
This passes on window size to as a flag to the chrome binary. 
E.g. `--window-size 1600,1200` is sent to the spawn of the chrome binary as `--window=size=1600,1200`

I tried to follow the same conventions in the original codebase.

_Some notes:_
1. I am using the `options` variable to pass window size through the RenderPDF constructor.
2. In the RenderPDF constructor, the window size option is saved as a class variable: `this.commandLineOptions`
3. spawnChrome() now uses a local array (`commandLineOptions`) to keep track of flags

Tested with: Google Chrome 60.0.3112.90 with window size specified and no window size specified.

I hope this is helpful. Thank you