### PR TITLE
Don't escape backslashes in macOS Chrome paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -219,16 +219,16 @@ class RenderPDF {
         }
         // macos
         if (await this.isCommandExists('/Applications/Google\ Chrome Canary.app/Contents/MacOS/Google\ Chrome')) {
-            return '/Applications/Google\\ Chrome Canary.app/Contents/MacOS/Google\\ Chrome';
+            return '/Applications/Google\ Chrome Canary.app/Contents/MacOS/Google\ Chrome';
         }
         if (await this.isCommandExists('/Applications/Google\ Chrome Dev.app/Contents/MacOS/Google\ Chrome')) {
-            return '/Applications/Google\\ Chrome Dev.app/Contents/MacOS/Google\\ Chrome';
+            return '/Applications/Google\ Chrome Dev.app/Contents/MacOS/Google\ Chrome';
         }
         if (await this.isCommandExists('/Applications/Google\ Chrome Beta.app/Contents/MacOS/Google\ Chrome')) {
-            return '/Applications/Google\\ Chrome Beta.app/Contents/MacOS/Google\\ Chrome';
+            return '/Applications/Google\ Chrome Beta.app/Contents/MacOS/Google\ Chrome';
         }
         if (await this.isCommandExists('/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome')) {
-            return '/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome';
+            return '/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome';
         }
         throw Error('Couldn\'t detect chrome version installed! use --chrome-binary to pass custom location');
     }


### PR DESCRIPTION
Since the call to `spawn` isn't using `shell: true`, the backslashes shouldn't be escaped. I encountered this with Node 8.8.1 and OSX 10.13.