### PR TITLE
Add support for paper width and height options

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ chrome-headless-render-pdf [OPTIONS] --url=URL --pdf=OUTPUT-FILE [--url=URL2 --p
     --include-background     include elements background
     --landscape              generate pdf in landscape orientation
     --window-size            specify window size, width(,x*)height (e.g. --window-size 1600,1200 or --window-size 1600x1200)
+    --paper-width            specify page width in inches (defaults to 8.5 inches)
+    --paper-height           specify page height in inches (defaults to 11 inches)
 
   Example:
     Render single pdf file

--- a/cli/chrome-headless-render-pdf.js
+++ b/cli/chrome-headless-render-pdf.js
@@ -16,7 +16,9 @@ const argv = require('minimist')(process.argv.slice(2), {
         'url',
         'pdf',
         'chrome-binary',
-        'window-size'
+        'window-size',
+        'paper-width',
+        'paper-height',
     ],
     boolean: [
         'no-margins',
@@ -56,6 +58,16 @@ if (typeof argv['chrome-binary'] === 'string') {
     chromeBinary = argv['chrome-binary'];
 }
 
+let paperWidth = undefined;
+if (typeof argv['paper-width'] === 'string') {
+    paperWidth = argv['paper-width'];
+}
+
+let paperHeight = undefined;
+if (typeof argv['paper-height'] === 'string') {
+    paperHeight = argv['paper-height'];
+}
+
 let landscape;
 if (argv['landscape']) {
     landscape = true;
@@ -80,7 +92,9 @@ if (argv['include-background']) {
             noMargins,
             includeBackground,
             chromeBinary,
-            windowSize
+            windowSize,
+            paperWidth,
+            paperHeight
         });
     } catch (e) {
         console.error(e);
@@ -112,6 +126,8 @@ function printHelp() {
     console.log('    --include-background     include elements background');
     console.log('    --landscape              generate pdf in landscape orientation');
     console.log('    --window-size            specify window size, width(,x*)height (e.g. --window-size 1600,1200 or --window-size 1600x1200)');
+    console.log('    --paper-width            specify page width in inches (defaults to 8.5 inches)');
+    console.log('    --paper-height           specify page height in inches (defaults to 11 inches)');
     console.log('');
     console.log('  Example:');
     console.log('    Render single pdf file');

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,8 @@ interface IRenderPdfOptions {
     landscape?: boolean;
     includeBackground?: boolean;
     windowSize?: boolean;
+    paperWidth?: string;
+    paperHeight?: string;
 }
 
 interface IJobPair {

--- a/index.js
+++ b/index.js
@@ -18,6 +18,8 @@ class RenderPDF {
             chromeBinary: def('chromeBinary', null),
             noMargins: def('noMargins', false),
             landscape: def('landscape', undefined),
+            paperWidth: def('paperWidth', undefined),
+            paperHeight: def('paperHeight', undefined),
             includeBackground: def('includeBackground', undefined)
         };
 
@@ -120,6 +122,13 @@ class RenderPDF {
             options.printBackground = !!this.options.includeBackground;
         }
 
+        if(this.options.paperWidth !== undefined) {
+            options.paperWidth = parseFloat(this.options.paperWidth);
+        }
+
+        if(this.options.paperHeight !== undefined) {
+            options.paperHeight = parseFloat(this.options.paperHeight);
+        }
         return options;
     }
 


### PR DESCRIPTION
Using a new --paper-width and --paper-height arguments

Example for A4:
chrome-headless-render-pdf --url http://google.com --pdf test.pdf --paper-width=8.3 --paper-height=11.7