### PR TITLE
Allow setting custom chrome options

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ chrome-headless-render-pdf [OPTIONS] --url=URL --pdf=OUTPUT-FILE [--url=URL2 --p
     --url                    url to load, for local files use: file:///path/to/file
     --pdf                    output for generated file can be relative to current directory
     --chrome-binary          set chrome location (use this options when autodetection fail)
-    --chrome-option          set chrome option
+    --chrome-option          set chrome option, options with leading dashes should use --chrome-option=value format
     --no-margins             disable default 1cm margins
     --include-background     include elements background
     --landscape              generate pdf in landscape orientation

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ chrome-headless-render-pdf [OPTIONS] --url=URL --pdf=OUTPUT-FILE [--url=URL2 --p
     --url                    url to load, for local files use: file:///path/to/file
     --pdf                    output for generated file can be relative to current directory
     --chrome-binary          set chrome location (use this options when autodetection fail)
+    --chrome-option          set chrome option
     --no-margins             disable default 1cm margins
     --include-background     include elements background
     --landscape              generate pdf in landscape orientation

--- a/cli/chrome-headless-render-pdf.js
+++ b/cli/chrome-headless-render-pdf.js
@@ -16,6 +16,7 @@ const argv = require('minimist')(process.argv.slice(2), {
         'url',
         'pdf',
         'chrome-binary',
+        'chrome-option',
         'window-size',
         'paper-width',
         'paper-height',
@@ -58,11 +59,11 @@ if (typeof argv['chrome-binary'] === 'string') {
     chromeBinary = argv['chrome-binary'];
 }
 
-let chromeOptions = [];
-for (let i = 0; i < process.argv.length; i++) {
-  if (process.argv[i] === '--chrome-option' && typeof process.argv[i + 1] === 'string') {
-    chromeOptions.push(process.argv[++i]);
-  }
+let chromeOptions = null;
+if (Array.isArray(argv['chrome-option'])) {
+  chromeOptions = argv['chrome-option'];
+} else if (typeof argv['chrome-option']) {
+  chromeOptions = [argv['chrome-option']];
 }
 
 let paperWidth = undefined;
@@ -130,7 +131,7 @@ function printHelp() {
     console.log('    --url                    url to load, for local files use: file:///path/to/file');
     console.log('    --pdf                    output for generated file can be relative to current directory');
     console.log('    --chrome-binary          set chrome location (use this options when autodetection fail)');
-    console.log('    --chrome-option          set chrome option');
+    console.log('    --chrome-option          set chrome option, options with leading dashes should use --chrome-option=value format');
     console.log('    --no-margins             disable default 1cm margins');
     console.log('    --include-background     include elements background');
     console.log('    --landscape              generate pdf in landscape orientation');

--- a/cli/chrome-headless-render-pdf.js
+++ b/cli/chrome-headless-render-pdf.js
@@ -58,6 +58,13 @@ if (typeof argv['chrome-binary'] === 'string') {
     chromeBinary = argv['chrome-binary'];
 }
 
+let chromeOptions = [];
+for (let i = 0; i < process.argv.length; i++) {
+  if (process.argv[i] === '--chrome-option' && typeof process.argv[i + 1] === 'string') {
+    chromeOptions.push(process.argv[++i]);
+  }
+}
+
 let paperWidth = undefined;
 if (typeof argv['paper-width'] === 'string') {
     paperWidth = argv['paper-width'];
@@ -92,6 +99,7 @@ if (argv['include-background']) {
             noMargins,
             includeBackground,
             chromeBinary,
+            chromeOptions,
             windowSize,
             paperWidth,
             paperHeight
@@ -122,6 +130,7 @@ function printHelp() {
     console.log('    --url                    url to load, for local files use: file:///path/to/file');
     console.log('    --pdf                    output for generated file can be relative to current directory');
     console.log('    --chrome-binary          set chrome location (use this options when autodetection fail)');
+    console.log('    --chrome-option          set chrome option');
     console.log('    --no-margins             disable default 1cm margins');
     console.log('    --include-background     include elements background');
     console.log('    --landscape              generate pdf in landscape orientation');

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,7 @@ interface IRenderPdfOptions {
     printLogs?: boolean;
     printErrors?: boolean;
     chromeBinary?: string;
+    chromeOptions: string[],
     noMargins?: boolean;
     landscape?: boolean;
     includeBackground?: boolean;

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ class RenderPDF {
             printLogs: def('printLogs', false),
             printErrors: def('printErrors', true),
             chromeBinary: def('chromeBinary', null),
+            chromeOptions: def('chromeOptions', []),
             noMargins: def('noMargins', false),
             landscape: def('landscape', undefined),
             paperWidth: def('paperWidth', undefined),
@@ -189,7 +190,7 @@ class RenderPDF {
              '--headless', 
              `--remote-debugging-port=${this.port}`, 
              '--disable-gpu'
-            ];
+            ].concat(this.options.chromeOptions);
 
         if (this.commandLineOptions.windowSize !== undefined ) {
           commandLineOptions.push(`--window-size=${this.commandLineOptions.windowSize[0]},${this.commandLineOptions.windowSize[1]}`);

--- a/index.js
+++ b/index.js
@@ -189,8 +189,9 @@ class RenderPDF {
         const commandLineOptions = [
              '--headless',
              `--remote-debugging-port=${this.port}`,
-             '--disable-gpu'
-            ].concat(this.options.chromeOptions);
+             '--disable-gpu',
+             ...this.options.chromeOptions
+            ];
 
         if (this.commandLineOptions.windowSize !== undefined ) {
           commandLineOptions.push(`--window-size=${this.commandLineOptions.windowSize[0]},${this.commandLineOptions.windowSize[1]}`);

--- a/index.js
+++ b/index.js
@@ -187,8 +187,8 @@ class RenderPDF {
         const chromeExec = this.options.chromeBinary || await this.detectChrome();
         this.log('Using', chromeExec);
         const commandLineOptions = [
-             '--headless', 
-             `--remote-debugging-port=${this.port}`, 
+             '--headless',
+             `--remote-debugging-port=${this.port}`,
              '--disable-gpu'
             ].concat(this.options.chromeOptions);
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "chrome-headless-render-pdf",
+  "name": "@dudeofawesome/chrome-headless-render-pdf",
   "version": "1.5.1",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@dudeofawesome/chrome-headless-render-pdf",
+  "name": "chrome-headless-render-pdf",
   "version": "1.5.1",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Headless Chrome in Travis CI only works with sandboxing disabled, so I needed to a way to set that option with this module. 

I added a `--chrome-option` argument which can be used multiple times to create an array of options that get added to the `commandLineOptions` array.

I've currently got a working version of this published on NPM at `@dudeofawesome/chrome-headless-render-pdf`.