### PR TITLE
Improve chrome detection on Linux

### DIFF
--- a/index.js
+++ b/index.js
@@ -245,6 +245,9 @@ class RenderPDF {
         if (await this.isCommandExists('chromium')) {
             return 'chromium';
         }
+        if (await this.isCommandExists('chromium-browser')) {
+            return 'chromium-browser';
+        }
         // windows
         if (await this.isCommandExists('chrome')) {
             return 'chrome';


### PR DESCRIPTION
This extends `detectChrome()` to work on distros (like Ubuntu and Alpine) where the binary is named `chromium-browser`.