### PR TITLE
Wait until page load to set virtual time budget

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,14 +87,15 @@ class RenderPDF {
                 await LayerTree.enable();
 
                 await Page.navigate({url});
-                await Emulation.setVirtualTimePolicy({policy: 'pauseIfNetworkFetchesPending', budget: 5000});
 
                 const loaded = this.cbToPromise(Page.loadEventFired);
-                const jsDone = this.cbToPromise(Emulation.virtualTimeBudgetExpired);
 
                 await this.profileScope('Wait for load', async () => {
                     await loaded;
                 });
+
+                await Emulation.setVirtualTimePolicy({policy: 'pauseIfNetworkFetchesPending', budget: 5000});
+                const jsDone = this.cbToPromise(Emulation.virtualTimeBudgetExpired);
 
                 await this.profileScope('Wait for js execution', async () => {
                     await jsDone;


### PR DESCRIPTION
This branch waits until after the page load event fires to set the JS time budget. This fixes an intermittent problem I see where the CLI appears to hang after connecting to Chrome and logging the "Opening [url]" line (more details in #29).
