### PR TITLE
Add option to connect to running chrome process

### DIFF
--- a/cli/chrome-headless-render-pdf.js
+++ b/cli/chrome-headless-render-pdf.js
@@ -17,6 +17,8 @@ const argv = require('minimist')(process.argv.slice(2), {
         'pdf',
         'chrome-binary',
         'chrome-option',
+        'remote-host',
+        'remote-port',
         'window-size',
         'paper-width',
         'paper-height',
@@ -67,6 +69,14 @@ if (Array.isArray(argv['chrome-option'])) {
   chromeOptions = [argv['chrome-option']];
 }
 
+let [remoteHost, remotePort] = [undefined, undefined];
+if (typeof argv['remote-host'] === 'string') {
+    remoteHost = argv['remote-host'];
+}
+if (typeof argv['remote-port'] === 'string') {
+    remotePort = argv['remote-port'];
+}
+
 let paperWidth = undefined;
 if (typeof argv['paper-width'] === 'string') {
     paperWidth = argv['paper-width'];
@@ -107,6 +117,8 @@ if(typeof argv['page-ranges'] === 'string') {
             includeBackground,
             chromeBinary,
             chromeOptions,
+            remoteHost,
+            remotePort,
             windowSize,
             paperWidth,
             paperHeight,
@@ -139,6 +151,8 @@ function printHelp() {
     console.log('    --pdf                    output for generated file can be relative to current directory');
     console.log('    --chrome-binary          set chrome location (use this options when autodetection fail)');
     console.log('    --chrome-option          set chrome option, can be used multiple times, e.g. --chrome-option=--no-sandbox');
+    console.log('    --remote-host            set chrome host (for remote process)');
+    console.log('    --remote-port            set chrome port (for remote process)');
     console.log('    --no-margins             disable default 1cm margins');
     console.log('    --include-background     include elements background');
     console.log('    --landscape              generate pdf in landscape orientation');

--- a/index.js
+++ b/index.js
@@ -8,7 +8,14 @@ class RenderPDF {
     constructor(options) {
         this.setOptions(options || {});
         this.chrome = null;
-        this.port = Math.floor(Math.random() * 10000 + 1000);
+
+        if (this.options.remoteHost) {
+          this.host = this.options.remoteHost;
+          this.port = this.options.remotePort;
+        } else {
+          this.host = 'localhost';
+          this.port = Math.floor(Math.random() * 10000 + 1000);
+        }
     }
 
     setOptions(options) {
@@ -17,6 +24,8 @@ class RenderPDF {
             printErrors: def('printErrors', true),
             chromeBinary: def('chromeBinary', null),
             chromeOptions: def('chromeOptions', []),
+            remoteHost: def('remoteHost', null),
+            remotePort: def('remotePort', 9222),
             noMargins: def('noMargins', false),
             landscape: def('landscape', undefined),
             paperWidth: def('paperWidth', undefined),
@@ -36,8 +45,7 @@ class RenderPDF {
 
     static async generateSinglePdf(url, filename, options) {
         const renderer = new RenderPDF(options);
-        await renderer.spawnChrome();
-        await renderer.waitForDebugPort();
+        await renderer.connectToChrome();
         try {
             const buff = await renderer.renderPdf(url, renderer.generatePdfOptions());
             fs.writeFileSync(filename, buff);
@@ -50,8 +58,7 @@ class RenderPDF {
 
     static async generatePdfBuffer(url, options) {
         const renderer = new RenderPDF(options);
-        await renderer.spawnChrome();
-        await renderer.waitForDebugPort();
+        await renderer.connectToChrome();
         try {
             return renderer.renderPdf(url, renderer.generatePdfOptions());
         } catch (e) {
@@ -63,8 +70,7 @@ class RenderPDF {
 
     static async generateMultiplePdf(pairs, options) {
         const renderer = new RenderPDF(options);
-        await renderer.spawnChrome();
-        await renderer.waitForDebugPort();
+        await renderer.connectToChrome();
         for (const job of pairs) {
             try {
                 const buff = await renderer.renderPdf(job.url, renderer.generatePdfOptions());
@@ -79,7 +85,7 @@ class RenderPDF {
 
     async renderPdf(url, options) {
         return new Promise((resolve, reject) => {
-            CDP({port: this.port}, async (client) => {
+            CDP({host: this.host, port: this.port}, async (client) => {
                 try{
                 this.log(`Opening ${url}`);
                 const {Page, Emulation, LayerTree} = client;
@@ -217,6 +223,14 @@ class RenderPDF {
         });
     }
 
+    async connectToChrome() {
+      if (!this.options.remoteHost) {
+        await this.spawnChrome();
+      }
+
+      await this.waitForDebugPort();
+    }
+
     async isCommandExists(cmd) {
         return new Promise((resolve, reject) => {
             commandExists(cmd, (err, exists) => {
@@ -266,14 +280,16 @@ class RenderPDF {
     }
 
     killChrome() {
-        this.chrome.kill(cp.SIGKILL);
+        if (!this.options.remoteHost) {
+            this.chrome.kill(cp.SIGKILL);
+        }
     }
 
     async waitForDebugPort() {
         this.log('Waiting for chrome to became available');
         while (true) {
             try {
-                await this.isPortOpen('localhost', this.port);
+                await this.isPortOpen(this.host, this.port);
                 this.log('Connected!');
                 await this.checkChromeVersion();
                 return;
@@ -285,7 +301,7 @@ class RenderPDF {
 
     async checkChromeVersion() {
         return new Promise((resolve) => {
-            CDP({port: this.port}, async (client) => {
+            CDP({host: this.host, port: this.port}, async (client) => {
                 try {
                     const {Browser} = client;
                     const version = await Browser.getVersion();


### PR DESCRIPTION
This branch allows chrome-headless-render-pdf to connect to an already running Chrome process. It adds two new options `remoteHost` and `remotePort`, and corresponding CLI options `--remote-host` and `--remote-port`. This would be a useful capability so that we can run our browser processes in a separate environment from the rest of our applications.

