### PR TITLE
Improve error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,8 @@ class RenderPDF {
                 });
             });
             server.on('error', () => {
-                server.listen(Math.floor(Math.random() * 30000) + 30000);
+                port = Math.floor(Math.random() * 30000) + 30000;
+                server.listen(port);
             });
             server.listen(port);
         })


### PR DESCRIPTION
Two fixes:
- `selectFreePort` was catching errors, but still returning the first port tested (even if it was already taken).
- `renderPdf` wasn't listening for errors when connecting to chrome; I was seeing them show up as unhandled rejections. `checkChromeVersion` was doing the right thing, but both are simpler when written using `await`.