### PR TITLE
automatically convert local file paths to file url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 
-# Usage: 
+# Usage:
 ```
 chrome-headless-render-pdf [OPTIONS] --url=URL --pdf=OUTPUT-FILE [--url=URL2 --pdf=OUTPUT-FILE2] ...
   Options:
     --help                   this screen
-    --url                    url to load, for local files use: file:///path/to/file
+    --url                    url to load, for local files use: file:///path/to/file or /path/to/file
     --pdf                    output for generated file can be relative to current directory
     --chrome-binary          set chrome location (use this options when autodetection fail)
     --chrome-option          set chrome option, can be used multiple times, e.g. --chrome-option=--no-sandbox
@@ -24,6 +24,8 @@ chrome-headless-render-pdf [OPTIONS] --url=URL --pdf=OUTPUT-FILE [--url=URL2 --p
       chrome-headless-render-pdf --url http://google.com --pdf test.pdf
     Render pdf from local file
       chrome-headless-render-pdf --url file:///tmp/example.html --pdf test.pdf
+    Render pdf from local file in current directory
+      chrome-headless-render-pdf --url example.html --pdf test.pdf
     Render multiple pdf files
       chrome-headless-render-pdf --url http://google.com --pdf test.pdf --url file:///tmp/example.html --pdf test2.pdf
 ```

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const cp = require('child_process');
 const net = require('net');
 const commandExists = require('command-exists');
+const fileUrl = require('file-url');
 
 class StreamReader {
     constructor(stream) {
@@ -110,6 +111,10 @@ class RenderPDF {
     }
 
     async renderPdf(url, options) {
+        if (!url.match(/^(https?|file):\/\//) && fs.existsSync(url)) {
+          url = fileUrl(url);
+        }
+
         const client = await CDP({host: this.host, port: this.port});
         this.log(`Opening ${url}`);
         const {Page, Emulation, LayerTree} = client;

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "babel-polyfill": "^6.23.0",
     "chrome-remote-interface": "^0.28.2",
     "command-exists": "^1.2.2",
+    "file-url": "^3.0.0",
     "minimist": "^1.2.3",
     "update-notifier": "^4.1.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1115,6 +1115,11 @@ file-uri-to-path@1.0.0:
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
   integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
+file-url@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/file-url/-/file-url-3.0.0.tgz#247a586a746ce9f7a8ed05560290968afc262a77"
+  integrity sha512-g872QGsHexznxkIAdK8UiZRe7SkE6kvylShU4Nsj8NvfvZag7S0QuQ4IgvPDkk75HxgjIVDwycFTDAgIiO4nDA==
+
 filename-regex@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"


### PR DESCRIPTION
In the current version of the script you must use the syntax `file:///path/to/file` when referencing a local file.  This works but can be difficult to work with when you simply want to build a pdf for a file in the current directory.  You can do something like `file://$(realpath index.html)` but that is not cross platform and doesn't work in environments like Git Bash for Windows.

This change utilizes the [file-url](https://www.npmjs.com/package/file-url) package to automatically convert local file paths to a file url.  It will only do so when the provided url does not start with `http`, `https`, or `file`.