### PR TITLE
Expose 'preferCSSPageSize' option

### DIFF
--- a/cli/chrome-headless-render-pdf.js
+++ b/cli/chrome-headless-render-pdf.js
@@ -34,6 +34,7 @@ const argv = require('minimist')(process.argv.slice(2), {
         'include-background',
         'landscape',
         'display-header-footer',
+        'prefer-css-page-size',
     ]
 });
 
@@ -91,6 +92,11 @@ if (typeof argv['paper-width'] === 'string') {
 let paperHeight = undefined;
 if (typeof argv['paper-height'] === 'string') {
     paperHeight = argv['paper-height'];
+}
+
+let preferCSSPageSize = undefined;
+if (argv['prefer-css-page-size']) {
+    preferCSSPageSize = true;
 }
 
 let landscape;
@@ -170,6 +176,7 @@ if(typeof argv['animation-time-budget'] === 'string') {
             windowSize,
             paperWidth,
             paperHeight,
+            preferCSSPageSize,
             pageRanges,
             scale,
             displayHeaderFooter,
@@ -213,6 +220,7 @@ function printHelp() {
     console.log('    --window-size            specify window size, width(,x*)height (e.g. --window-size 1600,1200 or --window-size 1600x1200)');
     console.log('    --paper-width            specify page width in inches (defaults to 8.5 inches)');
     console.log('    --paper-height           specify page height in inches (defaults to 11 inches)');
+    console.log('    --prefer-css-page-size   respect CSS specified @page size');
     console.log('    --page-ranges            specify pages to render default all pages,  e.g. 1-5, 8, 11-13');
     console.log('    --scale                  specify scale of the webpage rendering (defaults to 1)');
     console.log('    --display-header-footer  display text headers and footers');

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,6 +11,7 @@ interface IRenderPdfOptions {
     windowSize?: boolean;
     paperWidth?: string;
     paperHeight?: string;
+    preferCSSPageSize?: boolean;
     pageRanges?: string;
     scale?: number;
     displayHeaderFooter?: boolean;

--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ class RenderPDF {
             landscape: def('landscape', undefined),
             paperWidth: def('paperWidth', undefined),
             paperHeight: def('paperHeight', undefined),
+            preferCSSPageSize: def('preferCSSPageSize', undefined),
             includeBackground: def('includeBackground', undefined),
             pageRanges: def('pageRanges', undefined),
             scale: def('scale', undefined),
@@ -173,6 +174,10 @@ class RenderPDF {
 
         if(this.options.paperHeight !== undefined) {
             options.paperHeight = parseFloat(this.options.paperHeight);
+        }
+
+        if (this.options.preferCSSPageSize !== undefined) {
+            options.preferCSSPageSize = !!this.options.preferCSSPageSize;
         }
 
         if(this.options.pageRanges !== undefined) {


### PR DESCRIPTION
This option makes Chrome respect the paper size specified via the @page size attribute. This is a much cleaner and standards compliant solution than having manually having to specify the page dimensions in inches.

Based on pull request #50 by [djsutherland](https://github.com/djsutherland), which appears to be incomplete and unreviewed. 